### PR TITLE
Updated references so Deno 1.0.3 doesn't fail internally

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,10 +1,10 @@
 import HandlebarsJS from "https://dev.jspm.io/handlebars@4.7.6";
-import { walk } from "https://deno.land/std@0.51.0/fs/mod.ts";
+import { walk } from "https://deno.land/std@0.54.0/fs/mod.ts";
 import {
   globToRegExp,
   normalize,
   join,
-} from "https://deno.land/std@0.51.0/path/mod.ts";
+} from "https://deno.land/std@0.54.0/path/mod.ts";
 const { readFile } = Deno;
 
 interface HandlebarsConfig {

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -1,5 +1,5 @@
 import { Handlebars } from "../mod.ts";
-import { assert } from "https://deno.land/std@v0.51.0/testing/asserts.ts";
+import { assert } from "https://deno.land/std@v0.54.0/testing/asserts.ts";
 const { test } = Deno;
 
 test({


### PR DESCRIPTION
Using Deno 1.0.3, simply importing { Handlebars @ 0.2.2 } caused errors deep in the Deno std lib. updating the reference version to the latest Deno std@0.54.0 fixed the problem.