### PR TITLE
Ensure helpers set in config are registered

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -60,6 +60,12 @@ export class Handlebars {
     );
     partialsPathes && (await this.registerPartials(partialsPathes));
 
+    if (config.helpers) {
+      Object.keys(config.helpers).forEach((key) => {
+        HandlebarsJS.registerHelper(key, config.helpers[key]);
+      });
+    }
+
     const path = join(config.baseDir, view + config.extname);
     const body: string = await this.render(path, context);
 

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -5,11 +5,24 @@ const { test } = Deno;
 test({
   name: "Basic render test",
   async fn() {
-    const handle = new Handlebars();
+    const config = {
+      baseDir: "views",
+      extname: ".hbs",
+      layoutsDir: "layouts/",
+      partialsDir: "partials/",
+      defaultLayout: "main",
+      helpers: {
+        echoHelper: (m: string) => {
+          return m;
+        },
+      },
+      compilerOptions: undefined,
+    };
+    const handle = new Handlebars(config);
     const text = await handle.renderView("index", { name: "Alosaur" });
-    
     assert(text.includes("header!"));
     assert(text.includes("This is index page My name is Alosaur"));
+    assert(text.includes("This is an example of a helper"));
     assert(text.includes("title!"));
     assert(text.includes("<span>footer!</span>"));
     assert(text.includes("<span>index page!</span>"));

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -1,3 +1,4 @@
 This is index page My name is {{name}}
 <span>index page!</span>
+This is {{echoHelper "an example of a helper"}}
 {{> page/title }}


### PR DESCRIPTION
At the moment it looks like config for helpers is ignored and this change ensures these helpers are registered.

For now I have just add checks for this to the base test but don't hesitate to say if you think that this should be a separate test.