### PR TITLE
Export HandlebarsJS

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -7,6 +7,8 @@ import {
 } from "https://deno.land/std@0.80.0/path/mod.ts";
 const { readFile } = Deno;
 
+export { HandlebarsJS };
+
 export interface HandlebarsConfig {
   baseDir: string;
   extname: string;


### PR DESCRIPTION
So that the underlying JS implementation of handlebars is available to
anyone who needs to access anything not supported by this wrapper.