### PR TITLE
Improve performance by caching partials

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ const DEFAULT_HANDLEBARS_CONFIG: HandlebarsConfig = {
     extname: '.hbs',
     layoutsDir: 'layouts/',
     partialsDir: 'partials/',
+    cachePartials: true,
     defaultLayout: 'main',
     helpers: undefined,
     compilerOptions: undefined,
@@ -40,14 +41,5 @@ By default partials are registered (and so cached) the first time you call
 every time you render a view so that the rendering reflects the latest changes
 you have made to your partials.
 
-You can ensure this happens by passing `true` for the final `refreshPartials`
-parameter for `renderView` e.g.
-
-```
-const result: string = await handle.renderView(
-  'index',
-  { name: 'Alosaur' },
-  undefined,
-  true,
-);
-```
+You can ensure this happens by setting `cachePartials` to be false in your
+configuration.

--- a/README.md
+++ b/README.md
@@ -32,3 +32,22 @@ const DEFAULT_HANDLEBARS_CONFIG: HandlebarsConfig = {
 // Then render page to string
 const result: string = await handle.renderView('index', { name: 'Alosaur' });
 ```
+
+#### Rendering in development mode
+
+By default partials are registered (and so cached) the first time you call
+`renderView`. However, in development, it may be better to re-register them
+every time you render a view so that the rendering reflects the latest changes
+you have made to your partials.
+
+You can ensure this happens by passing `true` for the final `refreshPartials`
+parameter for `renderView` e.g.
+
+```
+const result: string = await handle.renderView(
+  'index',
+  { name: 'Alosaur' },
+  undefined,
+  true,
+);
+```

--- a/mod.ts
+++ b/mod.ts
@@ -14,6 +14,7 @@ export interface HandlebarsConfig {
   extname: string;
   layoutsDir: string;
   partialsDir: string;
+  cachePartials?: boolean;
   defaultLayout: string;
   // deno-lint-ignore no-explicit-any
   helpers: any;
@@ -26,6 +27,7 @@ const DEFAULT_HANDLEBARS_CONFIG: HandlebarsConfig = {
   extname: ".hbs",
   layoutsDir: "layouts/",
   partialsDir: "partials/",
+  cachePartials: true,
   defaultLayout: "main",
   helpers: undefined,
   compilerOptions: undefined,
@@ -66,7 +68,6 @@ export class Handlebars {
     view: string,
     context?: Record<string, unknown>,
     layout?: string,
-    refreshPartials?: boolean,
   ): Promise<string> {
     if (!view) {
       console.warn("View is null");
@@ -75,7 +76,7 @@ export class Handlebars {
 
     const config: HandlebarsConfig = this.config as HandlebarsConfig;
 
-    if (refreshPartials || !this.#havePartialsBeenRegistered) {
+    if (!config.cachePartials || !this.#havePartialsBeenRegistered) {
       await this.registerPartials();
     }
 


### PR DESCRIPTION
This will enable users of this package to improve performance in
production by not re-registering partials every time they render a view.

In development it can be helpful to re-register partials on each render,
so that the render reflects any changes you have made to the partials.
This behaviour can be retained by setting `cachePartials` to `false` in
the configuration