### PR TITLE
dev.jspm.io is now jspm.dev

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,4 @@
-import HandlebarsJS from "https://dev.jspm.io/handlebars@4.7.6";
+import HandlebarsJS from "https://jspm.dev/handlebars@4.7.6";
 import { walk } from "https://deno.land/std@0.110.0/fs/mod.ts";
 import {
   globToRegExp,


### PR DESCRIPTION
see [jspm.dev Release](https://jspm.org/jspm-dev-release)

>dev.jspm.io will still be available for a further 12 months until June 2021. Upgrading to jspm.dev should be a seamless upgrade path in most cases, with the main user-facing compatibility change being that not all internal subpaths are exposed due to the [code splitting optimizations](https://jspm.org/jspm-dev-release#package-optimization).

Follow the import at the top of mod.ts file 
```
import HandlebarsJS from "https://dev.jspm.io/handlebars@4.7.6";
```
The source map in external file can be fetched successfully in [jspm.dev](https://jspm.dev/npm:source-map@0.6?dew)  while returns 500 in [dev.jspm.io](https://dev.jspm.io/npm:source-map@0.6?dew).

Therefore it is suggested to use the new URL instead.