### PR TITLE
Switch to esm.sh source for handlebars package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-18.04
         strategy:
             matrix:
-                deno: [1.18.1]
+                deno: [1.24.0]
         name: Deno ${{ matrix.deno }}
         steps:
             - uses: actions/checkout@master

--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,4 @@
-import HandlebarsJS from "https://dev.jspm.io/handlebars@4.7.6";
+import HandlebarsJS from "https://esm.sh/handlebars@4.7.6";
 import { walk } from "https://deno.land/std@0.110.0/fs/mod.ts";
 import {
   globToRegExp,


### PR DESCRIPTION
Because dev.jspm.io has issues and installs are erroring

```
error: Import 'https://dev.jspm.io/npm:source-map@0.6?dew' failed: 500 Internal Server Error
    at https://dev.jspm.io/npm:handlebars@4.7.6/dist/cjs/handlebars/compiler/code-gen.dew.js:2:41
```

Note esm.sh's version of handlebars is only compatible with deno versions 1.24.0 and later and so this includes an upgrade of deno version for the tests