### PR TITLE
dump deno version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-18.04
         strategy:
             matrix:
-                deno: [1.18.1]
+                deno: [1.19.0]
         name: Deno ${{ matrix.deno }}
         steps:
             - uses: actions/checkout@master


### PR DESCRIPTION
fix Deno.File error message in build test 
see deno release [v.19.0](https://github.com/denoland/deno/releases/tag/v1.19.0)